### PR TITLE
Remove reliance on passing CONFIG_FPU in the wrappers

### DIFF
--- a/abi-extract-info/analyzers/struct_boundaries.py
+++ b/abi-extract-info/analyzers/struct_boundaries.py
@@ -274,7 +274,7 @@ class StructTests:
                         data["dtypes"].append(dtype_str)
                     if (
                         iteration["registers_fill"]
-                        or iteration["register_combined"]
+                        or iteration["registers_combined"]
                         or iteration["registers_pairs"]
                     ):
                         data["<="] = "in registers"
@@ -294,7 +294,7 @@ class StructTests:
                     if argc <= limit:
                         if (
                             iteration["registers_fill"]
-                            or iteration["register_combined"]
+                            or iteration["registers_combined"]
                             or iteration["registers_pairs"]
                         ):
                             if data["<="] == "in registers":

--- a/docs/add-wrapper.md
+++ b/docs/add-wrapper.md
@@ -53,14 +53,14 @@ Example:
 $ cat cc-wrapper
 #!/bin/bash
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d "$@"
 ```
 
 ```bash
 $ cat as-wrapper
 #!/bin/bash
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d "$@"
 ```
 
 ```bash
@@ -70,6 +70,5 @@ $ cat ld-wrapper
 riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d "$@"
 `````
 
-The `CONFIG_FPU` macro is required to indicate that the compiler supports hardware floating-point registers.
 The tool applies the `-O1` optimization flag by default for all compilers.
 

--- a/scripts/wrapper/cc/clang-rv32gc-ilp32/as-wrapper
+++ b/scripts/wrapper/cc/clang-rv32gc-ilp32/as-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-clang -march=rv32gc -mabi=ilp32 -DCONFIG_FPU=0 "$@"
+clang -march=rv32gc -mabi=ilp32 "$@"
 

--- a/scripts/wrapper/cc/clang-rv32gc-ilp32/cc-wrapper
+++ b/scripts/wrapper/cc/clang-rv32gc-ilp32/cc-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-clang -march=rv32gc -mabi=ilp32 -DCONFIG_FPU=0 "$@"
+clang -march=rv32gc -mabi=ilp32 "$@"
 

--- a/scripts/wrapper/cc/clang-rv32gc-ilp32d/as-wrapper
+++ b/scripts/wrapper/cc/clang-rv32gc-ilp32d/as-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-clang -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+clang -march=rv32gc -mabi=ilp32d "$@"
 

--- a/scripts/wrapper/cc/clang-rv32gc-ilp32d/cc-wrapper
+++ b/scripts/wrapper/cc/clang-rv32gc-ilp32d/cc-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-clang -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+clang -march=rv32gc -mabi=ilp32d "$@"
 

--- a/scripts/wrapper/cc/gcc-rv32gc-ilp32/as-wrapper
+++ b/scripts/wrapper/cc/gcc-rv32gc-ilp32/as-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32 -DCONFIG_FPU=0 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32 "$@"
 

--- a/scripts/wrapper/cc/gcc-rv32gc-ilp32/cc-wrapper
+++ b/scripts/wrapper/cc/gcc-rv32gc-ilp32/cc-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32 -DCONFIG_FPU=0 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32 "$@"
 

--- a/scripts/wrapper/cc/gcc-rv32gc-ilp32d/as-wrapper
+++ b/scripts/wrapper/cc/gcc-rv32gc-ilp32d/as-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d "$@"
 

--- a/scripts/wrapper/cc/gcc-rv32gc-ilp32d/cc-wrapper
+++ b/scripts/wrapper/cc/gcc-rv32gc-ilp32d/cc-wrapper
@@ -5,5 +5,5 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
-riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d -DCONFIG_FPU=1 "$@"
+riscv32-unknown-elf-gcc -march=rv32gc -mabi=ilp32d "$@"
 

--- a/src/arch/riscv.S
+++ b/src/arch/riscv.S
@@ -64,7 +64,7 @@ callee:
     sw x30, 120(t6)
 
     # Initialize t6 to point to the start of the regs_bank1 array
-.if CONFIG_FPU
+#ifndef __riscv_float_abi_soft
     la t6, regs_bank1
     fsd f0, 0(t6)
     fsd f1, 8(t6)
@@ -98,7 +98,7 @@ callee:
     fsd f29, 232(t6)
     fsd f30, 240(t6)
     fsd f31, 248(t6)
-.endif
+#endif
     la t6, regs_bank0
 
     # handle t6/x31

--- a/src/helper.c
+++ b/src/helper.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 extern unsigned regs_bank0[32];
-#if CONFIG_FPU
+#ifndef __riscv_float_abi_soft
 extern unsigned long long regs_bank1[32];
 #endif
 
@@ -22,15 +22,15 @@ void dump_information(unsigned* Stack) {
     // sizeof pointer (aka register)
     printf("// Header info\n");
     printf("%p\n0x%08x\n", Stack, sizeof(Stack));
-    // Number of register bancks
-#if CONFIG_FPU
+    // Number of register banks
+#ifndef __riscv_float_abi_soft
     printf("0x2\n");
 #else
     printf("0x1\n");
 #endif
     // bank0:  ID, size, number of regs
     printf("0x%x\n0x%x\n0x%x\n", /*ID*/ 0, sizeof(regs_bank0[0]), /*number of regs*/ ARRAY_LENGTH(regs_bank0));
-#if CONFIG_FPU
+#ifndef __riscv_float_abi_soft
     // bank1:  ID, size, number of regs
     printf("0x%x\n0x%x\n0x%x\n", /*ID*/ 1, sizeof(regs_bank0[1]), /*number of regs*/ ARRAY_LENGTH(regs_bank1));
 #endif
@@ -40,7 +40,7 @@ void dump_information(unsigned* Stack) {
     for(unsigned i=0; i<ARRAY_LENGTH(regs_bank0); ++i)
        printf("0x%x\n", regs_bank0[i]);
 
-#if CONFIG_FPU
+#ifndef __riscv_float_abi_soft
     // Dump register bank1: regs_bank1
     printf("// regs_bank1\n");
     for(unsigned i=0; i<ARRAY_LENGTH(regs_bank1); ++i)


### PR DESCRIPTION
Passing this definition in your custom wrapper is easy to forget and causes hard-to-debug errors.

Instead we check for `__riscv_float_abi_soft`. If this is predefined hardware floats are not supported by the ABI.

Also fix a minor bug in the struct boundaries analyzer. It only triggered when hardware floats were not supported.