### PR TITLE
Don't configure the wrapper scripts by setting PATH

### DIFF
--- a/abi-extract-info/__main__.py
+++ b/abi-extract-info/__main__.py
@@ -55,16 +55,14 @@ if __name__ == "__main__":
     # Hardcoded to RISCV FIXME
     Target = targetArch.RISCV()
 
-    # Set environment variable
-    helper.set_env(cc_option, sim_option)
-
     # Initialize the report driver with the report name
     Report = reportDriver.ReportDriver(ReportName, OptionParser)
 
     print(f"Running {cc_option} with {sim_option}...")
 
     is_verbose = OptionParser.get("verbose")
-    Driver = compilationDriver.CompilationDriver(is_verbose)
+    cc_path, sim_path = helper.get_cc_sim_paths(cc_option, sim_option)
+    Driver = compilationDriver.CompilationDriver(is_verbose, cc_path, sim_path)
 
     # Run tests and generate summary report
     run_analyzers(Driver, Report, Target)

--- a/abi-extract-info/compilationDriver.py
+++ b/abi-extract-info/compilationDriver.py
@@ -10,11 +10,11 @@ import subprocess
 
 
 class CompilationDriver:
-    def __init__(self, is_verbose):
-        self.cc = "cc-wrapper"
-        self.assembler = "as-wrapper"
-        self.linker = "ld-wrapper"
-        self.simulator = "sim-wrapper"
+    def __init__(self, is_verbose, cc_path, sim_path):
+        self.cc = str(cc_path / "cc-wrapper")
+        self.assembler = str(cc_path / "as-wrapper")
+        self.linker = str(cc_path / "ld-wrapper")
+        self.simulator = str(sim_path / "sim-wrapper")
         self.cflags = ["-O1"]
         self.is_verbose = is_verbose
 

--- a/abi-extract-info/helper.py
+++ b/abi-extract-info/helper.py
@@ -6,18 +6,19 @@
 # the LICENSE file in the root directory of this source tree.
 
 import os
+import pathlib
 
 
-# Add the compiler and simulator wrappers to the
-# PATH environment variable to enable a modular
-# approach for invoking various compilers and simulators.
-def set_env(cc, sim):
-    root_path = os.path.abspath(".")
-    wrapper_path = root_path + "/scripts/wrapper/"
-
-    # Set environment variable
-    os.environ["PATH"] = wrapper_path + f"/cc/{cc}:" + os.environ["PATH"]
-    os.environ["PATH"] = wrapper_path + f"/sim/{sim}:" + os.environ["PATH"]
+def get_cc_sim_paths(cc, sim):
+    """
+    Resolve the paths to the wrapper by searching relative to this source file.
+    """
+    wrapper_path = (
+        pathlib.Path(__file__) / ".." / ".." / "scripts" / "wrapper"
+    ).resolve()
+    cc_path = wrapper_path / "cc" / f"{cc}"
+    sim_path = wrapper_path / "sim" / f"{sim}"
+    return cc_path, sim_path
 
 
 # Responsible for reading a file and returning its contents.


### PR DESCRIPTION
Instead resolve and pass the absolute path to the compilation driver. Resolve the files relative to __file__ instead of the current working directory, this allows the wrappers to be found regardless from what the cwd is.