### PR TITLE
Add reference reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
   * [Ask for Help](#ask-for-help)
   * [Pull Request Lifecycle](#pull-request-lifecycle)
   * [Development Environment Setup](#development-environment-setup)
+  * [Reference Reports](#reference-reports)
   * [Sign Your Commits](#sign-your-commits)
 
 Welcome! We are glad that you want to contribute to our project! 💖
@@ -89,8 +90,15 @@ Make sure the required toolchain and simulator are available in the `PATH`. By d
 4. **Run the Project** \
 Start the application with the following command:
 ```bash
-$ python3 abi-extract-info.py
+$ python3 abi-extract-info
 ```
+
+
+## Reference Reports
+
+The `reports/` directory contains references of what the reports should contain.
+If analyzers are added, or changed in any other way, please update the reference
+reports in this directory.
 
 
 ## Sign Your Commits

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -2,8 +2,6 @@
 
 This document outlines the framework's file structure, describing the organization and purpose of each file and directory.
 
-# TODO
-
 #### `abi-extract-info/` Directory:
 
 Contains the Python source of the `abi-extract-info` utility:
@@ -34,5 +32,11 @@ Contains the Python source of the `abi-extract-info` utility:
 - `helper.c`    - C source code for architecture dump information.
 ```
 
-### `tmp/` Directory
+#### `reports/` Directory:
+
+Reference reports for every provided wrapper. Can be used for testing or for
+comparing results from different compilers.
+
+#### `tmp/` Directory
+
 Stores temporary files generated during execution.

--- a/reports/clang-rv32gc-ilp32_qemu-riscv32.report
+++ b/reports/clang-rv32gc-ilp32_qemu-riscv32.report
@@ -1,0 +1,95 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : float
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- long_long : double
+ - args 1-4 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 5   [low], [high]: [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+
+Struct argument passing test:
+- sizeof(S) <= 8 : passed in registers
+- sizeof(S) >  8 : passed by ref: [stack]
+  - char : short : int : long : float : a0, a1
+  - long long : double [low], [high]: a0, a1
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : float
+ - passed in registers: a0
+- long long : double
+ - passed in registers [low], [high]: a0, a1
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/clang-rv32gc-ilp32d_qemu-riscv32.report
+++ b/reports/clang-rv32gc-ilp32d_qemu-riscv32.report
@@ -1,0 +1,113 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- long_long
+ - args 1-4 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 5   [low], [high]: [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- float
+ - args 1-16 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7 a0 a1 a2 a3 a4 a5 a6 a7
+ - args 17  : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- double
+ - args 1-8 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7
+ - args 9-12 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 13  [low], [high]: [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+
+Struct argument passing test:
+- sizeof(S) <= 8 : passed in registers
+- sizeof(S) >  8 : passed by ref: [stack]
+  - char : short : int : long : a0, a1
+  - long long [low], [high]: a0, a1
+  - float : fa0, fa1
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - double : fa0, fa1
+- argc <= 2 : passed in registers
+- argc >  2 : passed by ref: [stack]
+  - float,double : double,float : float,float : double,double
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long
+ - passed in registers: a0
+- long long
+ - passed in registers [low], [high]: a0, a1
+- float : double
+ - passed in registers: fa0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/gcc-rv32gc-ilp32_qemu-riscv32.report
+++ b/reports/gcc-rv32gc-ilp32_qemu-riscv32.report
@@ -1,0 +1,93 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : float
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+- long_long : double
+ - args 1-4 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 5   [low], [high]: [stack]
+
+Struct argument passing test:
+- sizeof(S) <= 8 : passed in registers
+- sizeof(S) >  8 : passed by ref: [stack]
+  - char : short : int : long : float : a0, a1
+  - long long : double [low], [high]: a0, a1
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : float
+ - passed in registers: a0
+- long long : double
+ - passed in registers [low], [high]: a0, a1
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/gcc-rv32gc-ilp32d_qemu-riscv32.report
+++ b/reports/gcc-rv32gc-ilp32d_qemu-riscv32.report
@@ -1,0 +1,109 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : long : void* : float
+ - 8: long long : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : long : void : float
+ - 8: long_long : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+- long_long
+ - args 1-4 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 5   [low], [high]: [stack]
+- float
+ - args 1-16 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7 a0 a1 a2 a3 a4 a5 a6 a7
+ - args 17  : [stack]
+- double
+ - args 1-8 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7
+ - args 9-12 [low], [high]: [a0, a1] [a2, a3] [a4, a5] [a6, a7]
+ - args 13  [low], [high]: [stack]
+
+Struct argument passing test:
+- sizeof(S) <= 8 : passed in registers
+- sizeof(S) >  8 : passed by ref: [stack]
+  - char : short : int : long : a0, a1
+  - long long [low], [high]: a0, a1
+  - float : fa0, fa1
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - double : fa0, fa1
+- argc <= 2 : passed in registers
+- argc >  2 : passed by ref: [stack]
+  - float,double : double,float : float,float : double,double
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long
+ - passed in registers: a0
+- long long
+ - passed in registers [low], [high]: a0, a1
+- float : double
+ - passed in registers: fa0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.


### PR DESCRIPTION
These reports can be used to do integration testing of the tool or more easily comparing with other compilers by diffing the reports.