### PR TITLE
Add rv64 support

### DIFF
--- a/abi-extract-info/analyzers/argpass.py
+++ b/abi-extract-info/analyzers/argpass.py
@@ -445,6 +445,12 @@ class ArgPassAnalyzer(analyzer.Analyzer):
                 dump_information = dumpInformation.DumpInformation()
                 dump_information.parse(stdout)
 
+                for (
+                    bank_id,
+                    reg_info,
+                ) in dump_information.get_reg_bank_infos().items():
+                    self.Target.set_register_size(bank_id, reg_info["size"])
+
                 # Get the stack and register bank information
                 stack = dump_information.get_stack()
                 reg_banks = dump_information.get_reg_banks()

--- a/abi-extract-info/analyzers/struct_boundaries.py
+++ b/abi-extract-info/analyzers/struct_boundaries.py
@@ -142,10 +142,10 @@ class StructTests:
             # so we cannot consider the size of an int. If an int is 32-bit,
             # it would split the value, which is incorrect the double data type.
             register_bank_count = self.Target.get_register_bank_count()
-            if dtype == "double" and register_bank_count == "0x2":
-                register_size = self.Target.get_type_details("double")["size"]
+            if dtype == "double" and register_bank_count == 2:
+                register_size = self.Target.get_register_size("regs_bank1")
             else:
-                register_size = self.Target.get_type_details("int")["size"]
+                register_size = self.Target.get_register_size("regs_bank0")
 
             if len(iterations) > 1:
                 iteration = iterations[-2]
@@ -527,7 +527,7 @@ class StructBoundaryAnalyzer(analyzer.Analyzer):
             # The struct has not been passed by reference yet, so increment
             # the char limit by one.
             char_limit += 1
-            if char_limit == 10:
+            if char_limit == 20:
                 print("breaking for safe purposes [struct_boundaries]")
                 break
 
@@ -584,7 +584,7 @@ class StructBoundaryAnalyzer(analyzer.Analyzer):
                     stack = dump_information.get_stack()
                     reg_banks = dump_information.get_reg_banks()
                     # Get the register bank count from the header dump information.
-                    register_bank_count = dump_information.get_header_info(2)
+                    register_bank_count = dump_information.get_reg_bank_count()
 
                     # Extract the struct sizeof from C test case.
                     # Regular expression to match the size
@@ -615,7 +615,6 @@ class StructBoundaryAnalyzer(analyzer.Analyzer):
         return StructTests(self.Target).prepare_summary(results)
 
     def analyze(self):
-        # TODO: Test for 64-bit scenarios.
         content = self.analyze_struct_boundaries()
 
         content += StructBoundaryAnalyzerSpecialCase(

--- a/abi-extract-info/targetArch.py
+++ b/abi-extract-info/targetArch.py
@@ -11,6 +11,7 @@ class TargetArch:
         self.type_details = dict()
         self.argument_registers = []
         self.register_bank_count = 0
+        self.register_size = {}
 
     def set_type_details(self, type_details):
         self.type_details = type_details
@@ -35,6 +36,17 @@ class TargetArch:
 
     def get_type(self):
         raise NotImplementedError("Subclasses should implement this!")
+
+    def set_register_size(self, regs_bank, size):
+        self.register_size[regs_bank] = size
+
+    def get_register_size(self, regs_bank=None):
+        # Get the size of the general purpose register bank if none is
+        # specified. We consider this to be the first bank in the result of
+        # get_registers()
+        return self.register_size[
+            list(self.get_registers())[0] if regs_bank is None else regs_bank
+        ]
 
 
 # RISCV target specific

--- a/reports/clang-rv64gc-lp64_qemu-riscv64.report
+++ b/reports/clang-rv64gc-lp64_qemu-riscv64.report
@@ -1,0 +1,91 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : long_long : float : double
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+
+Struct argument passing test:
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - char : short : int : long : long long : float : double : a0, a1
+- floating point members
+  - float : double : float, float : float, char : float, char, char : a0
+  - double, double : double, char : float, float, float : a0, a1
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : long long : float : double
+ - passed in registers: a0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/clang-rv64gc-lp64d_qemu-riscv64.report
+++ b/reports/clang-rv64gc-lp64d_qemu-riscv64.report
@@ -1,0 +1,105 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : long_long
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- float
+ - args 1-16 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7 a0 ft0 a1 ft1 a2 ft2 a3 a4 a5 a6 a7
+ - args 17  : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+- double
+ - args 1-16 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7 a0 a1 a2 a3 a4 a5 a6 a7
+ - args 17  : [stack]
+ - WARNING: multiple value occurrences detected in (t0, [stack])
+
+Struct argument passing test:
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - char : short : int : long : long long : float : a0, a1
+  - double : fa0, fa1
+- floating point members
+  - float : double : fa0
+  - float, float : double, double : fa0, fa1
+  - float, char : double, char : fa0, a0
+  - float, float, float : a0, a1
+  - float, char, char : a0
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : long long
+ - passed in registers: a0
+- float : double
+ - passed in registers: fa0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/gcc-rv64gc-lp64_qemu-riscv64.report
+++ b/reports/gcc-rv64gc-lp64_qemu-riscv64.report
@@ -1,0 +1,87 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : long_long : float : double
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+
+Struct argument passing test:
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - char : short : int : long : long long : float : double : a0, a1
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : long long : float : double
+ - passed in registers: a0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/reports/gcc-rv64gc-lp64d_qemu-riscv64.report
+++ b/reports/gcc-rv64gc-lp64d_qemu-riscv64.report
@@ -1,0 +1,93 @@
+Datatype size test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype align test:
+ - 1: char : signed char : unsigned char
+ - 2: short
+ - 4: int : float
+ - 8: long : long long : void* : double
+ - 16: long double
+
+Datatype signedness test:
+ - signed char : short : int : long : long long : float : double : long double
+
+Datatype struct size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype struct align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union size test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Datatype union align test:
+ - 1: char : signed_char : unsigned_char
+ - 2: short
+ - 4: int : float
+ - 8: long : long_long : void : double
+ - 16: long_double
+
+Stack direction test:
+- The stack grows downwards.
+
+Stack alignment test:
+- Number of least significant 0 bits: 4
+- Stack is aligned to 16 bytes.
+
+Argument passing test:
+- char : short : int : long : long_long
+ - args 1-8 : a0 a1 a2 a3 a4 a5 a6 a7
+ - args 9   : [stack]
+- float : double
+ - args 1-16 : fa0 fa1 fa2 fa3 fa4 fa5 fa6 fa7 a0 a1 a2 a3 a4 a5 a6 a7
+ - args 17  : [stack]
+
+Struct argument passing test:
+- sizeof(S) <= 16 : passed in registers
+- sizeof(S) >  16 : passed by ref: [stack]
+  - char : short : int : long : long long : float : a0, a1
+  - double : fa0, fa1
+- empty struct is ignored by C compiler.
+
+Endianess test:
+- Wrote (as ull):  0123456789abcdef
+- Read  (as char): efcdab8967452301
+- This system is little-endian.
+
+Caller/callee-saved test:
+ - caller-saved s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11
+ - callee-saved t0, t1, t2, a0, a1, a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
+
+Return registers:
+- char : short : int : long : long long
+ - passed in registers: a0
+- float : double
+ - passed in registers: fa0
+
+Bit-Field test:
+- sum(bit-fields) > sizeof(datatype)
+  - char : short : int : long : long_long
+    - Extra padding.
+    - Little-endian.
+- sum(bit-fields) < sizeof(datatype)
+  - char
+    - No extra padding.
+  - short : int : long : long_long
+    - No extra padding.
+    - Little-endian.

--- a/scripts/wrapper/cc/clang-rv64gc-lp64/as-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64/as-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/clang-rv64gc-lp64/cc-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64/cc-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/clang-rv64gc-lp64/ld-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64/ld-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/clang-rv64gc-lp64d/as-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64d/as-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/cc/clang-rv64gc-lp64d/cc-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64d/cc-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/cc/clang-rv64gc-lp64d/ld-wrapper
+++ b/scripts/wrapper/cc/clang-rv64gc-lp64d/ld-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+clang -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64/as-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64/as-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64/cc-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64/cc-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64/ld-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64/ld-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64 "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64d/as-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64d/as-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64d/cc-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64d/cc-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/cc/gcc-rv64gc-lp64d/ld-wrapper
+++ b/scripts/wrapper/cc/gcc-rv64gc-lp64d/ld-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+riscv64-unknown-elf-gcc -march=rv64gc -mabi=lp64d "$@"
+

--- a/scripts/wrapper/sim/qemu-riscv64/sim-wrapper
+++ b/scripts/wrapper/sim/qemu-riscv64/sim-wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025-present, Synopsys, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPL-3.0 license found in
+# the LICENSE file in the root directory of this source tree.
+
+qemu-riscv64 -r 5.10 "$@"
+

--- a/src/arch/riscv.S
+++ b/src/arch/riscv.S
@@ -4,19 +4,29 @@
 # This source code is licensed under the GPL-3.0 license found in
 # the LICENSE file in the root directory of this source tree.
 
+#if __riscv_xlen == 64
+#define T6_STACK_OFFSET -8
+#define S2_STACK_OFFSET -16
+#else
+#define T6_STACK_OFFSET -4
+#define S2_STACK_OFFSET -8
+#endif
+
 .data
 .globl regs_bank0
 .globl regs_bank1
 
 regs_bank0:
     .rept 32
-    .word 0
+    .dword 0
     .endr
+    .size regs_bank0, .-regs_bank0
 
 regs_bank1:
     .rept 32
     .dword 0
     .endr
+    .size regs_bank1, .-regs_bank1
 
 .text
 .align  1
@@ -26,8 +36,46 @@ regs_bank1:
 .globl  set_registers
 .type   callee, @function
 callee:
+#if __riscv_xlen == 64
     # Save t6 to the stack
-    sw t6, -4(sp)
+    sd t6, T6_STACK_OFFSET(sp)
+
+    # Initialize t6 to point to the start of the regs_bank0 array
+    la t6, regs_bank0
+    sd x0, 0(t6)
+    sd x1, 8(t6)
+    sd x2, 16(t6)
+    sd x3, 24(t6)
+    sd x4, 32(t6)
+    sd x5, 40(t6)
+    sd x6, 48(t6)
+    sd x7, 56(t6)
+    sd x8, 64(t6)
+    sd x9, 72(t6)
+    sd x10, 80(t6)
+    sd x11, 88(t6)
+    sd x12, 96(t6)
+    sd x13, 104(t6)
+    sd x14, 112(t6)
+    sd x15, 120(t6)
+    sd x16, 128(t6)
+    sd x17, 136(t6)
+    sd x18, 144(t6)
+    sd x19, 152(t6)
+    sd x20, 160(t6)
+    sd x21, 168(t6)
+    sd x22, 176(t6)
+    sd x23, 184(t6)
+    sd x24, 192(t6)
+    sd x25, 200(t6)
+    sd x26, 208(t6)
+    sd x27, 216(t6)
+    sd x28, 224(t6)
+    sd x29, 232(t6)
+    sd x30, 240(t6)
+#else
+    # Save t6 to the stack
+    sw t6, T6_STACK_OFFSET(sp)
 
     # Initialize t6 to point to the start of the regs_bank0 array
     la t6, regs_bank0
@@ -62,6 +110,7 @@ callee:
     sw x28, 112(t6)
     sw x29, 116(t6)
     sw x30, 120(t6)
+#endif
 
     # Initialize t6 to point to the start of the regs_bank1 array
 #ifndef __riscv_float_abi_soft
@@ -101,14 +150,37 @@ callee:
 #endif
     la t6, regs_bank0
 
+#if __riscv_xlen == 64
     # handle t6/x31
-    lw x30, -4(sp)
+    ld x30, T6_STACK_OFFSET(sp)
+    sd x30, 248(t6)
+    ld x30, 240(t6)
+    # Note: t6 register itself (x31) is not stored to regs_bank0 array
+
+    # save the callee-saved register
+    sd s2, S2_STACK_OFFSET(sp)
+
+    # save the return address to a callee-saved register
+    ld s2, 8(t6)
+
+    # call to dump_information
+    mv x10, sp
+    call dump_information
+
+    # restore the return address
+    addi ra, s2, 0
+
+    # restore the calee-saved register
+    ld s2, S2_STACK_OFFSET(sp)
+#else
+    # handle t6/x31
+    lw x30, T6_STACK_OFFSET(sp)
     sw x30, 124(t6)
     lw x30, 120(t6)
     # Note: t6 register itself (x31) is not stored to regs_bank0 array
 
     # save the callee-saved register
-    sw s2, -8(sp)
+    sw s2, S2_STACK_OFFSET(sp)
 
     # save the return address to a callee-saved register
     lw s2, 4(t6)
@@ -121,7 +193,8 @@ callee:
     addi ra, s2, 0
 
     # restore the calee-saved register
-    lw s2, -8(sp)
+    lw s2, S2_STACK_OFFSET(sp)
+#endif
 
     ret
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -9,15 +9,24 @@
 
 // Helper function for dumping informatino
 #include <stdio.h>
+#include <stdint.h>
 
-extern unsigned regs_bank0[32];
+#if __riscv_xlen == 64
+#define REGISTER_WORD uint64_t
+#define REGISTER_WORD_FORMAT "0x%llx\n"
+#else
+#define REGISTER_WORD uint32_t
+#define REGISTER_WORD_FORMAT "0x%x\n"
+#endif
+
+extern REGISTER_WORD regs_bank0[32];
 #ifndef __riscv_float_abi_soft
-extern unsigned long long regs_bank1[32];
+extern uint64_t regs_bank1[32];
 #endif
 
 #define ARRAY_LENGTH(x) sizeof(x)/sizeof(x[0])
 
-void dump_information(unsigned* Stack) {
+void dump_information(REGISTER_WORD* Stack) {
     // current stack
     // sizeof pointer (aka register)
     printf("// Header info\n");
@@ -29,16 +38,22 @@ void dump_information(unsigned* Stack) {
     printf("0x1\n");
 #endif
     // bank0:  ID, size, number of regs
-    printf("0x%x\n0x%x\n0x%x\n", /*ID*/ 0, sizeof(regs_bank0[0]), /*number of regs*/ ARRAY_LENGTH(regs_bank0));
+    printf("%s\n0x%x\n0x%x\n",
+           /*ID*/ "regs_bank0",
+           sizeof(regs_bank0[0]),
+           /*number of regs*/ ARRAY_LENGTH(regs_bank0));
 #ifndef __riscv_float_abi_soft
     // bank1:  ID, size, number of regs
-    printf("0x%x\n0x%x\n0x%x\n", /*ID*/ 1, sizeof(regs_bank0[1]), /*number of regs*/ ARRAY_LENGTH(regs_bank1));
+    printf("%s\n0x%x\n0x%x\n",
+           /*ID*/ "regs_bank1",
+           sizeof(regs_bank1[0]),
+           /*number of regs*/ ARRAY_LENGTH(regs_bank1));
 #endif
 
     // Dump register bank0: regs_bank0
     printf("// regs_bank0\n");
     for(unsigned i=0; i<ARRAY_LENGTH(regs_bank0); ++i)
-       printf("0x%x\n", regs_bank0[i]);
+       printf(REGISTER_WORD_FORMAT, regs_bank0[i]);
 
 #ifndef __riscv_float_abi_soft
     // Dump register bank1: regs_bank1
@@ -50,7 +65,7 @@ void dump_information(unsigned* Stack) {
     // stack: 32 entries (128 bytes on 32bit system)
     printf("// Start of stack dump: %p\n", Stack);
     for(unsigned i=0; i<32; ++i){
-        printf("%p : 0x%x\n", &Stack[i], Stack[i]);
+        printf("%p : " REGISTER_WORD_FORMAT, &Stack[i], Stack[i]);
     }
     printf("// Done\n");
 }


### PR DESCRIPTION
- Adds wrappers for rv64 lp64 & lp64d.
- Removes assumptions about register size in hex utils.
- Make native utilities compatible with rv64