### PR TITLE
Remove `reset_registers`

### DIFF
--- a/abi-extract-info/analyzers/returnpass.py
+++ b/abi-extract-info/analyzers/returnpass.py
@@ -87,7 +87,6 @@ inline static double ull_as_double(unsigned long long lhs)
 
     def generate_single_call_prototypes(self):
         self.append("extern void foo (void);")
-        self.append("extern void reset_registers (void);")
 
     def generate_single_call_bar(self, hvalue_return):
         if self._dtype == "float":
@@ -101,7 +100,6 @@ inline static double ull_as_double(unsigned long long lhs)
             """
 %s bar (void) {
     /* %s a = %s; */
-    reset_registers();
     return %s;
 }
 """

--- a/abi-extract-info/analyzers/saved.py
+++ b/abi-extract-info/analyzers/saved.py
@@ -46,7 +46,6 @@ class ReturnGenerator:
 
     def generate_prototypes_main(self):
         self.append("extern void callee (void);")
-        self.append("extern void reset_registers (void);")
         self.append("extern void set_registers (int);")
         self.append("#define dump callee // this is temporary.")
         self.append("int* aux (void);")
@@ -81,7 +80,6 @@ void aux (void) {
         self.append(
             """
 int main (void) {
-    reset_registers();
     set_registers(%s);
     aux();
     dump();

--- a/abi-extract-info/analyzers/struct_boundaries.py
+++ b/abi-extract-info/analyzers/struct_boundaries.py
@@ -78,7 +78,6 @@ struct assignmentType {
 
     def generate_single_call_prototypes(self):
         self.append("extern void callee(struct structType);")
-        self.append("extern void reset_registers();")
 
     def generate_single_call_main(self, hvalues):
         hvalues_str = []
@@ -101,7 +100,6 @@ union {
 
 int main (void) {
     printf("Sizeof(struct structType): %%d\\n", sizeof(struct structType));
-    reset_registers();
     callee(u.structTypeObject);
 
     return 0;

--- a/src/arch/riscv.S
+++ b/src/arch/riscv.S
@@ -32,7 +32,6 @@ regs_bank1:
 .align  1
 .globl  callee
 .globl  get_stack_pointer
-.globl  reset_registers
 .globl  set_registers
 .type   callee, @function
 callee:
@@ -199,25 +198,6 @@ callee:
     ret
 
     .size callee, .-callee
-
-reset_registers:
-    # cleanup: clear or reset registers
-    li x5, 0  # t0
-    li x6, 0  # t1
-    li x7, 0  # t2
-    li x10, 0 # a0
-    li x11, 0 # a1
-    li x12, 0 # a2
-    li x13, 0 # a3
-    li x14, 0 # a4
-    li x15, 0 # a5
-    li x16, 0 # a6
-    li x17, 0 # a7
-    li x28, 0 # t3
-    li x29, 0 # t4
-    li x30, 0 # t5
-    li x31, 0 # t6
-    ret
 
 get_stack_pointer:
     mv a0, sp


### PR DESCRIPTION
This was added in the past when multiple tests were ran in a single process. This is no longer needed.

The implementation of this function also relies on information we instead should be deriving through analysis.